### PR TITLE
PYTEST: Update workflow to skip tests that require secrets

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,6 +6,14 @@ name: Checks
 on:
   push:
     branches: ["main"]
+  pull_request:
+    branches: ["main"]
+    types:
+      - opened
+      # ready_for_review occurs when a draft PR is turned to non-draft
+      - ready_for_review
+      # synchronize occurs whenever commits are pushed to the PR branch
+      - synchronize
 
 defaults:
   run:
@@ -59,8 +67,13 @@ jobs:
         if: matrix.cov-report
         run: echo PYTEST_ADDOPTS="$PYTEST_ADDOPTS --cov --cov-report=xml" >> $GITHUB_ENV
       - name: Run pytest
+        # Skip tests that require API Keys (Secrets) when pull request is opened
         run: |
-          pytest -v
+          if [ ${{ github.event_name }} == 'pull_request' ]; then
+            pytest -v -m "not secrets"
+          else
+            pytest -v
+          fi
       - name: Upload coverage report as job artifact
         if: matrix.cov-report
         uses: actions/upload-artifact@v4

--- a/primo/utils/tests/test_census_utils.py
+++ b/primo/utils/tests/test_census_utils.py
@@ -81,6 +81,7 @@ def test_get_fips_code():
     assert get_fips_code(41, -76) == "420792166011027"
 
 
+@pytest.mark.secrets
 def test_generate_geo_identifiers():
     CENSUS_KEY = get_census_key()
     client = CensusClient(CENSUS_KEY)

--- a/primo/utils/tests/test_demo_utils.py
+++ b/primo/utils/tests/test_demo_utils.py
@@ -209,6 +209,7 @@ STATE_CODE = 37
 STATE_CODE_FAKE = 60
 
 
+@pytest.mark.secrets
 def test_get_population_by_state():
     result_df = get_population_by_state(STATE_CODE)
     assert "Total Population" in result_df.columns

--- a/primo/utils/tests/test_elevation_utils.py
+++ b/primo/utils/tests/test_elevation_utils.py
@@ -25,6 +25,7 @@ from primo.utils.elevation_utils import (
 )
 
 
+@pytest.mark.secrets
 def test_get_bing_maps_api_key():
     key = get_bing_maps_api_key()
     assert len(key) == 64
@@ -82,6 +83,7 @@ def test_haversine_distance(lat1, lon1, lat2, lon2, return_value, status):
         # Add more test cases as needed
     ],
 )
+@pytest.mark.secrets
 def test_get_route(start_coord, end_coord, status):
     key = get_bing_maps_api_key()
     if status:
@@ -110,6 +112,7 @@ def test_get_route(start_coord, end_coord, status):
         # Add more test cases as needed
     ],
 )
+@pytest.mark.secrets
 def test_get_nearest_road_point(lat, lon, return_tuple, status):
     if status:
         assert np.allclose(
@@ -137,6 +140,7 @@ def test_get_nearest_road_point(lat, lon, return_tuple, status):
         # Add more test cases as needed
     ],
 )
+@pytest.mark.secrets
 def test_accessibility(lat, lon, return_value, status):
     if status:
         assert np.isclose(

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 testpaths = primo/
+markers =
+    secrets: tests that rely on repository secrets which may not be accesible to PRs


### PR DESCRIPTION
## Fixes/Addresses/Summary/Motivation:

https://github.com/NEMRI-org/primo-optimizer/issues/2

## Changes proposed in this PR:
- Introduce a new pytest marker called `secrets`
- Marks tests that require API keys with the secrets marker
- Skip those tests when PR is opened.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
